### PR TITLE
Fix API errors feedback

### DIFF
--- a/redmine_zulip/lib/zulip_hooks.rb
+++ b/redmine_zulip/lib/zulip_hooks.rb
@@ -133,10 +133,9 @@ class NotificationHook < Redmine::Hook::Listener
         req.add_field('User-Agent', 'ZulipRedmine/0.1')
         req.set_form_data(data)
 
-        begin
-            http.request(req)
-        rescue Net::HTTPBadResponse => e
-            Rails.logger.error "Error while POSTing to Zulip: #{e}"
+        res = http.request(req)
+        unless res.code == "200"
+          Rails.logger.error "Error while POSTing to Zulip: #{res.body}"
         end
     end
 end


### PR DESCRIPTION
Hello,

I have noticed that API errors logging is not working, since [Net::HTTP#request method never raises Net::* exceptions](https://ruby-doc.org/stdlib-2.5.3/libdoc/net/http/rdoc/Net/HTTP.html#method-i-request) but returns an [HTTPResponse](https://ruby-doc.org/stdlib-2.5.3/libdoc/net/http/rdoc/Net/HTTPResponse.html) object.

Thank you very much