### PR TITLE
Improve settings

### DIFF
--- a/redmine_zulip/app/views/settings/_redmine_zulip.html.erb
+++ b/redmine_zulip/app/views/settings/_redmine_zulip.html.erb
@@ -1,4 +1,9 @@
 <p>
+    <%= content_tag(:label, l(:zulip_settings_label_url)) %>
+    <%= text_field_tag 'settings[zulip_url]', @settings["zulip_url"] %>
+</p>
+
+<p>
     <%= content_tag(:label, l(:zulip_settings_label_email)) %>
     <%= text_field_tag 'settings[zulip_email]', @settings["zulip_email"] %>
 </p>
@@ -11,16 +16,6 @@
 <p>
     <%= content_tag(:label, l(:zulip_settings_label_stream)) %>
     <%= text_field_tag 'settings[zulip_stream]', @settings["zulip_stream"] %>
-</p>
-
-<p>
-    <%= content_tag(:label, l(:zulip_settings_label_server)) %>
-    <%= text_field_tag 'settings[zulip_server]', @settings["zulip_server"] %>
-</p>
-
-<p>
-    <%= content_tag(:label, l(:zulip_settings_label_port)) %>
-    <%= text_field_tag 'settings[zulip_port]', @settings["zulip_port"] %>
 </p>
 
 <p>

--- a/redmine_zulip/config/locales/en.yml
+++ b/redmine_zulip/config/locales/en.yml
@@ -1,11 +1,10 @@
 en:
   zulip_settings_header: Zulip Plugin Configuration
-  zulip_settings_label_stream: Stream name
-  zulip_settings_label_server: Server URL
-  zulip_settings_label_port: Server Port
+  zulip_settings_label_stream: Zulip stream
+  zulip_settings_label_url: Zulip URL
   zulip_settings_label_email: Zulip Email
   zulip_settings_label_api_key: Zulip API key
   zulip_settings_label_projects: Projects
   field_zulip_email: Zulip Email
   field_zulip_api_key: Zulip API key
-  field_zulip_stream: Stream name
+  field_zulip_stream: Zulip stream

--- a/redmine_zulip/init.rb
+++ b/redmine_zulip/init.rb
@@ -20,6 +20,5 @@ Redmine::Plugin.register :redmine_zulip do
              :zulip_email => "",
              :zulip_api_key => "",
              :zulip_stream => "",
-             :zulip_server => "",
-             :zulip_port => ""}
+             :zulip_url => ""}
 end


### PR DESCRIPTION
Hello, this is an improvement submission

I have just setup the plugin on my Redmine instance following [the instructions guide](https://zulipchat.com/integrations/doc/redmine) and I found a bit confusing to set server's `hostname/path` without any protocol on one field, then server's **port** on a separate field.

It would be more straight forward for Redmine administrators to set only one field with the full URL `https://yourZulipDomain.zulipchat.com/api`. 

The online documentation **should be updated**.

This pull request contains all commits of #8 #9 #10 feel free to merge only this one or each one separately.

Thank you very much