### PR TITLE
fix #30 catch record not found exception for group users

### DIFF
--- a/config/locales/tr.yml
+++ b/config/locales/tr.yml
@@ -1,0 +1,65 @@
+tr:
+  label_redmine_zulip: Zulip
+  zulip_settings_header: Zulip Eklenti Yapılandırması
+  zulip_settings_label_url: Zulip URL
+  zulip_settings_label_email: Zulip Bot E-postası
+  zulip_settings_label_api_key: Zulip Bot API anahtarı
+  zulip_settings_label_stream_expression: Kanal adı
+  zulip_settings_label_issue_updates_subject_expression: >
+    İş güncellemeleri konusu
+  zulip_settings_label_version_updates_subject_expression: >
+    Sürüm güncellemeleri konusu
+  field_zulip_url: Zulip URL
+  field_zulip_email: Zulip e-posta
+  field_zulip_api_key: Zulip Bot API anahtarı
+  field_zulip_stream_expression: Kanal adı
+  field_zulip_issue_updates_subject_expression: >
+    İş güncellemeleri konusu
+  field_zulip_version_updates_subject_expression: >
+    Sürüm güncellemeleri konusu
+  zulip_notify_assignment: >
+    %{user} [[%{project}#%{id}] %{subject}](%{url}) işini **size** **atadı**:
+
+
+    ~~~quote
+
+    %{description}
+
+    ~~~
+
+
+    * **%{status_label}**: %{status}
+
+
+  zulip_notify_unassignment: >
+    %{user} [[%{project}#%{id}] %{subject}](%{url}) işini **sizden** **kaldırdı**.
+
+  zulip_notify_updated: >
+    %{user} [[%{project}#%{id}] %{subject}](%{url}) işini **güncelledi**.
+
+  zulip_notify_destroyed: >
+    %{user} **%{id}: %{subject}** işini **sildi**.
+
+  zulip_init_issue_subject: >
+    %{user} [[%{project}#%{id}] %{subject}](%{url}) işini **oluşturdu**:
+
+
+    ~~~quote
+
+    %{description}
+
+    ~~~
+
+    * **%{assigned_to_label}**: %{assigned_to}
+
+    * **%{status_label}**: %{status}
+
+  zulip_update_version_subject_added: >
+    %{user} [[%{project}#%{id}] %{subject}](%{url}) işini **%{fixed_version}** sürümüne **ekledi**.
+
+  zulip_update_version_subject_removed: >
+    %{user} [[%{project}#%{id}] %{subject}](%{url}) işini **%{fixed_version}** sürümünden **çıkardı**.
+
+  zulip_update_version_subject_status: >
+    %{user} [[%{project}#%{id}] %{subject}](%{url}) işinin durumunu
+    *~~%{previous_status}~~* durumundan **%{current_status}** durumuna **değiştirdi**. 

--- a/db/migrate/20130920172651_add_zulip_auth_to_project.rb
+++ b/db/migrate/20130920172651_add_zulip_auth_to_project.rb
@@ -1,4 +1,4 @@
-class AddZulipAuthToProject < ActiveRecord::Migration
+class AddZulipAuthToProject < ActiveRecord::Migration[5.2]
     def change
         add_column :projects, :zulip_email, :string, :default => "", :null => false
         add_column :projects, :zulip_api_key, :string, :default => "", :null => false

--- a/db/migrate/20190408170051_upgrade_zulip_settings_to_project.rb
+++ b/db/migrate/20190408170051_upgrade_zulip_settings_to_project.rb
@@ -1,4 +1,4 @@
-class UpgradeZulipSettingsToProject < ActiveRecord::Migration
+class UpgradeZulipSettingsToProject < ActiveRecord::Migration[5.2]
   def change
     remove_column :projects, :zulip_email, :string
     remove_column :projects, :zulip_api_key, :string

--- a/db/migrate/20191015151700_rename_boolean_settings.rb
+++ b/db/migrate/20191015151700_rename_boolean_settings.rb
@@ -1,4 +1,4 @@
-class RenameBooleanSettings < ActiveRecord::Migration
+class RenameBooleanSettings < ActiveRecord::Migration[5.2]
   def change
     rename_column :projects, :zulip_subject_issue,   :zulip_issue_updates
     rename_column :projects, :zulip_subject_version, :zulip_version_updates

--- a/db/migrate/20191015152900_add_subjects_pattern_settings.rb
+++ b/db/migrate/20191015152900_add_subjects_pattern_settings.rb
@@ -1,4 +1,4 @@
-class AddSubjectsPatternSettings < ActiveRecord::Migration
+class AddSubjectsPatternSettings < ActiveRecord::Migration[5.2]
   def change
     rename_column :projects, :zulip_stream, :zulip_stream_expression
     add_column :projects, :zulip_issue_updates_subject_expression,   :string

--- a/db/migrate/20191015182300_set_default_patterns.rb
+++ b/db/migrate/20191015182300_set_default_patterns.rb
@@ -1,4 +1,4 @@
-class SetDefaultPatterns < ActiveRecord::Migration
+class SetDefaultPatterns < ActiveRecord::Migration[5.2]
   def change
     Setting.plugin_redmine_zulip[:zulip_stream_expression] = "${project_name}"
     Setting.plugin_redmine_zulip[:zulip_issue_updates_subject_expression] = "${issue_subject}"

--- a/db/migrate/20191018212300_remove_boolean_settings.rb
+++ b/db/migrate/20191018212300_remove_boolean_settings.rb
@@ -1,4 +1,4 @@
-class RemoveBooleanSettings < ActiveRecord::Migration
+class RemoveBooleanSettings < ActiveRecord::Migration[5.2]
   def change
     remove_column :projects, :zulip_private_messages, :boolean
     remove_column :projects, :zulip_issue_updates,    :boolean

--- a/db/migrate/20191018213300_add_zulip_server_settings_to_projects.rb
+++ b/db/migrate/20191018213300_add_zulip_server_settings_to_projects.rb
@@ -1,4 +1,4 @@
-class AddZulipServerSettingsToProjects < ActiveRecord::Migration
+class AddZulipServerSettingsToProjects < ActiveRecord::Migration[5.2]
   def change
     add_column :projects, :zulip_url,     :string
     add_column :projects, :zulip_email,   :string

--- a/init.rb
+++ b/init.rb
@@ -1,4 +1,4 @@
-require "redmine_zulip"
+require File.expand_path('lib/redmine_zulip', __dir__)
 
 Redmine::Plugin.register :redmine_zulip do
   name 'Zulip'
@@ -7,6 +7,8 @@ Redmine::Plugin.register :redmine_zulip do
   version RedmineZulip::VERSION
   url 'https://github.com/zulip/zulip-redmine-plugin'
   author_url 'https://www.zulip.org/'
+
+  requires_redmine version_or_higher: '4.0.0'
 
   settings partial: "settings/redmine_zulip", default: {
     "zulip_url" => "",
@@ -17,3 +19,4 @@ Redmine::Plugin.register :redmine_zulip do
     "zulip_version_updates_subject_expression" => "Version ${version_name}"
   }
 end
+

--- a/lib/redmine_zulip.rb
+++ b/lib/redmine_zulip.rb
@@ -1,5 +1,5 @@
 module RedmineZulip
-  VERSION = "3.0.0"
+  VERSION = "4.1.0"
 end
 Issue.send(:include, RedmineZulip::IssuePatch)
 Project.send(:include, RedmineZulip::ProjectPatch)

--- a/lib/redmine_zulip.rb
+++ b/lib/redmine_zulip.rb
@@ -1,9 +1,6 @@
 module RedmineZulip
-  VERSION = "2.1.2"
+  VERSION = "3.0.0"
 end
-
-Rails.configuration.to_prepare do
-  Issue.send(:include, RedmineZulip::IssuePatch)
-  Project.send(:include, RedmineZulip::ProjectPatch)
-  ProjectsController.send(:helper, RedmineZulip::ProjectSettingsTabs)
-end
+Issue.send(:include, RedmineZulip::IssuePatch)
+Project.send(:include, RedmineZulip::ProjectPatch)
+ProjectsController.send(:helper, RedmineZulip::ProjectSettingsTabs)

--- a/lib/redmine_zulip/issue_patch.rb
+++ b/lib/redmine_zulip/issue_patch.rb
@@ -112,7 +112,7 @@ module RedmineZulip
     def notify_assignment
       locale = assigned_to.language.present? ?
                  assigned_to.language : Setting.default_language
-      message = I18n.t("zulip_notify_assignment", {
+      message = I18n.t("zulip_notify_assignment", **{
         locale: locale,
         user: User.current.name,
         id: id,
@@ -144,7 +144,7 @@ module RedmineZulip
       )
       locale = previous_assigned_to.language.present? ?
                  previous_assigned_to.language : Setting.default_language
-      message = I18n.t("zulip_notify_unassignment", {
+      message = I18n.t("zulip_notify_unassignment", **{
         user: User.current.name,
         id: id,
         url: url,
@@ -162,7 +162,7 @@ module RedmineZulip
     def notify_assigned_to_issue_updated
       locale = assigned_to.language.present? ?
                  assigned_to.language : Setting.default_language
-      message = I18n.t("zulip_notify_updated", {
+      message = I18n.t("zulip_notify_updated", **{
         user: User.current.name,
         id: id,
         url: url,
@@ -223,7 +223,7 @@ module RedmineZulip
     def notify_assigned_to_issue_destroyed
       locale = assigned_to.language.present? ?
                  assigned_to.language : Setting.default_language
-      message = I18n.t("zulip_notify_destroyed", {
+      message = I18n.t("zulip_notify_destroyed", **{
         user: User.current.name,
         id: id,
         project: project.name,
@@ -239,7 +239,7 @@ module RedmineZulip
 
     def init_issue_subject
       locale = Setting.default_language
-      message = I18n.t("zulip_init_issue_subject", {
+      message = I18n.t("zulip_init_issue_subject", **{
         locale: locale,
         user: User.current.name,
         id: id,
@@ -270,7 +270,7 @@ module RedmineZulip
 
     def update_issue_subject
       locale = Setting.default_language
-      message = I18n.t("zulip_notify_updated", {
+      message = I18n.t("zulip_notify_updated", **{
         locale: locale,
         user: User.current.name,
         id: id,
@@ -341,7 +341,7 @@ module RedmineZulip
     end
 
     def update_issue_subject_destroyed
-      message = I18n.t("zulip_notify_destroyed", {
+      message = I18n.t("zulip_notify_destroyed", **{
         locale: Setting.default_language,
         user: User.current.name,
         id: id,
@@ -357,7 +357,7 @@ module RedmineZulip
     end
 
     def update_version_subject_added
-      message = I18n.t("zulip_update_version_subject_added", {
+      message = I18n.t("zulip_update_version_subject_added", **{
         locale: Setting.default_language,
         user: User.current.name,
         id: id,
@@ -378,7 +378,7 @@ module RedmineZulip
       previous_fixed_version = Version.find(
         previous_changes["fixed_version_id"].first
       )
-      message = I18n.t("zulip_update_version_subject_removed", {
+      message = I18n.t("zulip_update_version_subject_removed", **{
         locale: Setting.default_language,
         user: User.current.name,
         id: id,
@@ -397,7 +397,7 @@ module RedmineZulip
 
     def update_version_subject_status
       previous_status_id = previous_changes["status_id"].first
-      message = I18n.t("zulip_update_version_subject_status", {
+      message = I18n.t("zulip_update_version_subject_status", **{
         locale: Setting.default_language,
         user: User.current.name,
         id: id,
@@ -416,7 +416,7 @@ module RedmineZulip
     end
 
     def update_version_subject_destroyed
-      message = I18n.t("zulip_notify_destroyed", {
+      message = I18n.t("zulip_notify_destroyed", **{
         locale: Setting.default_language,
         user: User.current.name,
         id: id,

--- a/lib/redmine_zulip/issue_patch.rb
+++ b/lib/redmine_zulip/issue_patch.rb
@@ -112,7 +112,7 @@ module RedmineZulip
     def notify_assignment
       locale = assigned_to.language.present? ?
                  assigned_to.language : Setting.default_language
-      message = I18n.t("zulip_notify_assignment", {
+      message = I18n.t("zulip_notify_assignment", **{
         locale: locale,
         user: User.current.name,
         id: id,
@@ -145,7 +145,7 @@ module RedmineZulip
       if previous_changes.nil?
         locale = previous_assigned_to.language.present? ?
                   previous_assigned_to.language : Setting.default_language
-        message = I18n.t("zulip_notify_unassignment", {
+        message = I18n.t("zulip_notify_unassignment", **{
           user: User.current.name,
           id: id,
           url: url,
@@ -164,7 +164,7 @@ module RedmineZulip
     def notify_assigned_to_issue_updated
       locale = assigned_to.language.present? ?
                  assigned_to.language : Setting.default_language
-      message = I18n.t("zulip_notify_updated", {
+      message = I18n.t("zulip_notify_updated", **{
         user: User.current.name,
         id: id,
         url: url,
@@ -225,7 +225,7 @@ module RedmineZulip
     def notify_assigned_to_issue_destroyed
       locale = assigned_to.language.present? ?
                  assigned_to.language : Setting.default_language
-      message = I18n.t("zulip_notify_destroyed", {
+      message = I18n.t("zulip_notify_destroyed", **{
         user: User.current.name,
         id: id,
         project: project.name,
@@ -241,7 +241,7 @@ module RedmineZulip
 
     def init_issue_subject
       locale = Setting.default_language
-      message = I18n.t("zulip_init_issue_subject", {
+      message = I18n.t("zulip_init_issue_subject", **{
         locale: locale,
         user: User.current.name,
         id: id,
@@ -272,7 +272,7 @@ module RedmineZulip
 
     def update_issue_subject
       locale = Setting.default_language
-      message = I18n.t("zulip_notify_updated", {
+      message = I18n.t("zulip_notify_updated", **{
         locale: locale,
         user: User.current.name,
         id: id,
@@ -346,7 +346,7 @@ module RedmineZulip
     end
 
     def update_issue_subject_destroyed
-      message = I18n.t("zulip_notify_destroyed", {
+      message = I18n.t("zulip_notify_destroyed", **{
         locale: Setting.default_language,
         user: User.current.name,
         id: id,
@@ -362,7 +362,7 @@ module RedmineZulip
     end
 
     def update_version_subject_added
-      message = I18n.t("zulip_update_version_subject_added", {
+      message = I18n.t("zulip_update_version_subject_added", **{
         locale: Setting.default_language,
         user: User.current.name,
         id: id,
@@ -383,7 +383,7 @@ module RedmineZulip
       previous_fixed_version = Version.find(
         previous_changes["fixed_version_id"].first
       )
-      message = I18n.t("zulip_update_version_subject_removed", {
+      message = I18n.t("zulip_update_version_subject_removed", **{
         locale: Setting.default_language,
         user: User.current.name,
         id: id,
@@ -402,7 +402,7 @@ module RedmineZulip
 
     def update_version_subject_status
       previous_status_id = previous_changes["status_id"].first
-      message = I18n.t("zulip_update_version_subject_status", {
+      message = I18n.t("zulip_update_version_subject_status", **{
         locale: Setting.default_language,
         user: User.current.name,
         id: id,
@@ -421,7 +421,7 @@ module RedmineZulip
     end
 
     def update_version_subject_destroyed
-      message = I18n.t("zulip_notify_destroyed", {
+      message = I18n.t("zulip_notify_destroyed", **{
         locale: Setting.default_language,
         user: User.current.name,
         id: id,


### PR DESCRIPTION
I'm not a ruby developer but at least I catched the case the assigned_to_id is a group user
sending a message in notify_unassignment to all group members in case of a group assignment may be too noisy
better concept would be to have also groups available in zulip?