### PR TITLE
Update plugin for Redmine 5.x/6.x and Ruby 3 compatibility (v4.0.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Get Zulip notifications for your Redmine issues!
 | 1.x                          | 3.x             |
 | 2.x                          | 3.x             |
 | 3.x                          | 4.x             |
+| 4.x                          | 5.x / 6.x       |
 
 ## Installing
 
@@ -40,20 +41,20 @@ corner, then click on **Plugins**.
 Find the **Redmine Zulip** plugin, and click **Configure**. You must now set the
 following:
 
-* Zulip URL (e.g `https://yourZulipDomain.zulipchat.com/`)
-* Zulip Bot E-mail
-* Zulip Bot API key
-* Stream name __*__
-* Issue updates subject __*__
-* Version updates subject __*__
+- Zulip URL (e.g `https://yourZulipDomain.zulipchat.com/`)
+- Zulip Bot E-mail
+- Zulip Bot API key
+- Stream name **\***
+- Issue updates subject **\***
+- Version updates subject **\***
 
-_* You may set dynamic values by using the following self-explanatory
+_\* You may set dynamic values by using the following self-explanatory
 variables:_
 
-* ${issue_id}
-* ${issue_subject}
-* ${project_name}
-* ${version_name}
+- ${issue_id}
+- ${issue_subject}
+- ${project_name}
+- ${version_name}
 
 #### Project settings
 

--- a/db/migrate/20130920172651_add_zulip_auth_to_project.rb
+++ b/db/migrate/20130920172651_add_zulip_auth_to_project.rb
@@ -1,4 +1,4 @@
-class AddZulipAuthToProject < ActiveRecord::Migration
+class AddZulipAuthToProject < ActiveRecord::Migration[4.2]
     def change
         add_column :projects, :zulip_email, :string, :default => "", :null => false
         add_column :projects, :zulip_api_key, :string, :default => "", :null => false

--- a/db/migrate/20190408170051_upgrade_zulip_settings_to_project.rb
+++ b/db/migrate/20190408170051_upgrade_zulip_settings_to_project.rb
@@ -1,4 +1,4 @@
-class UpgradeZulipSettingsToProject < ActiveRecord::Migration
+class UpgradeZulipSettingsToProject < ActiveRecord::Migration[4.2]
   def change
     remove_column :projects, :zulip_email, :string
     remove_column :projects, :zulip_api_key, :string

--- a/db/migrate/20191015151700_rename_boolean_settings.rb
+++ b/db/migrate/20191015151700_rename_boolean_settings.rb
@@ -1,4 +1,4 @@
-class RenameBooleanSettings < ActiveRecord::Migration
+class RenameBooleanSettings < ActiveRecord::Migration[4.2]
   def change
     rename_column :projects, :zulip_subject_issue,   :zulip_issue_updates
     rename_column :projects, :zulip_subject_version, :zulip_version_updates

--- a/db/migrate/20191015152900_add_subjects_pattern_settings.rb
+++ b/db/migrate/20191015152900_add_subjects_pattern_settings.rb
@@ -1,4 +1,4 @@
-class AddSubjectsPatternSettings < ActiveRecord::Migration
+class AddSubjectsPatternSettings < ActiveRecord::Migration[4.2]
   def change
     rename_column :projects, :zulip_stream, :zulip_stream_expression
     add_column :projects, :zulip_issue_updates_subject_expression,   :string

--- a/db/migrate/20191015182300_set_default_patterns.rb
+++ b/db/migrate/20191015182300_set_default_patterns.rb
@@ -1,4 +1,4 @@
-class SetDefaultPatterns < ActiveRecord::Migration
+class SetDefaultPatterns < ActiveRecord::Migration[4.2]
   def change
     Setting.plugin_redmine_zulip[:zulip_stream_expression] = "${project_name}"
     Setting.plugin_redmine_zulip[:zulip_issue_updates_subject_expression] = "${issue_subject}"

--- a/db/migrate/20191018212300_remove_boolean_settings.rb
+++ b/db/migrate/20191018212300_remove_boolean_settings.rb
@@ -1,4 +1,4 @@
-class RemoveBooleanSettings < ActiveRecord::Migration
+class RemoveBooleanSettings < ActiveRecord::Migration[4.2]
   def change
     remove_column :projects, :zulip_private_messages, :boolean
     remove_column :projects, :zulip_issue_updates,    :boolean

--- a/db/migrate/20191018213300_add_zulip_server_settings_to_projects.rb
+++ b/db/migrate/20191018213300_add_zulip_server_settings_to_projects.rb
@@ -1,4 +1,4 @@
-class AddZulipServerSettingsToProjects < ActiveRecord::Migration
+class AddZulipServerSettingsToProjects < ActiveRecord::Migration[4.2]
   def change
     add_column :projects, :zulip_url,     :string
     add_column :projects, :zulip_email,   :string

--- a/init.rb
+++ b/init.rb
@@ -1,4 +1,4 @@
-require "redmine_zulip"
+require File.dirname(__FILE__) + "/lib/redmine_zulip"
 
 Redmine::Plugin.register :redmine_zulip do
   name 'Zulip'

--- a/lib/redmine_zulip.rb
+++ b/lib/redmine_zulip.rb
@@ -1,9 +1,7 @@
 module RedmineZulip
-  VERSION = "2.1.2"
+  VERSION = "4.0.0"
 end
 
-Rails.configuration.to_prepare do
-  Issue.send(:include, RedmineZulip::IssuePatch)
-  Project.send(:include, RedmineZulip::ProjectPatch)
-  ProjectsController.send(:helper, RedmineZulip::ProjectSettingsTabs)
-end
+Issue.prepend(RedmineZulip::IssuePatch)
+Project.prepend(RedmineZulip::ProjectPatch)
+ProjectsController.prepend(RedmineZulip::ProjectSettingsTabs)

--- a/lib/redmine_zulip/issue_patch.rb
+++ b/lib/redmine_zulip/issue_patch.rb
@@ -112,7 +112,7 @@ module RedmineZulip
     def notify_assignment
       locale = assigned_to.language.present? ?
                  assigned_to.language : Setting.default_language
-      message = I18n.t("zulip_notify_assignment", {
+      message = I18n.t("zulip_notify_assignment", **{
         locale: locale,
         user: User.current.name,
         id: id,
@@ -144,7 +144,7 @@ module RedmineZulip
       )
       locale = previous_assigned_to.language.present? ?
                  previous_assigned_to.language : Setting.default_language
-      message = I18n.t("zulip_notify_unassignment", {
+      message = I18n.t("zulip_notify_unassignment", **{
         user: User.current.name,
         id: id,
         url: url,
@@ -162,7 +162,7 @@ module RedmineZulip
     def notify_assigned_to_issue_updated
       locale = assigned_to.language.present? ?
                  assigned_to.language : Setting.default_language
-      message = I18n.t("zulip_notify_updated", {
+      message = I18n.t("zulip_notify_updated", **{
         user: User.current.name,
         id: id,
         url: url,
@@ -223,7 +223,7 @@ module RedmineZulip
     def notify_assigned_to_issue_destroyed
       locale = assigned_to.language.present? ?
                  assigned_to.language : Setting.default_language
-      message = I18n.t("zulip_notify_destroyed", {
+      message = I18n.t("zulip_notify_destroyed", **{
         user: User.current.name,
         id: id,
         project: project.name,
@@ -239,7 +239,7 @@ module RedmineZulip
 
     def init_issue_subject
       locale = Setting.default_language
-      message = I18n.t("zulip_init_issue_subject", {
+      message = I18n.t("zulip_init_issue_subject", **{
         locale: locale,
         user: User.current.name,
         id: id,
@@ -270,7 +270,7 @@ module RedmineZulip
 
     def update_issue_subject
       locale = Setting.default_language
-      message = I18n.t("zulip_notify_updated", {
+      message = I18n.t("zulip_notify_updated", **{
         locale: locale,
         user: User.current.name,
         id: id,
@@ -341,7 +341,7 @@ module RedmineZulip
     end
 
     def update_issue_subject_destroyed
-      message = I18n.t("zulip_notify_destroyed", {
+      message = I18n.t("zulip_notify_destroyed", **{
         locale: Setting.default_language,
         user: User.current.name,
         id: id,
@@ -357,7 +357,7 @@ module RedmineZulip
     end
 
     def update_version_subject_added
-      message = I18n.t("zulip_update_version_subject_added", {
+      message = I18n.t("zulip_update_version_subject_added", **{
         locale: Setting.default_language,
         user: User.current.name,
         id: id,
@@ -378,7 +378,7 @@ module RedmineZulip
       previous_fixed_version = Version.find(
         previous_changes["fixed_version_id"].first
       )
-      message = I18n.t("zulip_update_version_subject_removed", {
+      message = I18n.t("zulip_update_version_subject_removed", **{
         locale: Setting.default_language,
         user: User.current.name,
         id: id,
@@ -397,7 +397,7 @@ module RedmineZulip
 
     def update_version_subject_status
       previous_status_id = previous_changes["status_id"].first
-      message = I18n.t("zulip_update_version_subject_status", {
+      message = I18n.t("zulip_update_version_subject_status", **{
         locale: Setting.default_language,
         user: User.current.name,
         id: id,
@@ -416,7 +416,7 @@ module RedmineZulip
     end
 
     def update_version_subject_destroyed
-      message = I18n.t("zulip_notify_destroyed", {
+      message = I18n.t("zulip_notify_destroyed", **{
         locale: Setting.default_language,
         user: User.current.name,
         id: id,


### PR DESCRIPTION
I have fixed the required path for Zeitwerk autoloading (init.rb) and replace rails.configuration.to_prepare with direct module prepend
Switch from send(:include) to prepend for IssuePatch/ProjectPatch
Add  double-splat to all I18n.t calls for Ruby 3 keyword args
Add [4.2] version specifier to all ActiveRecord::Migration classes
Bump plugin version from 2.1.2 to 4.0.0
Update README compatibility table with 4.x -> Redmine 5.x/6.x
